### PR TITLE
AD- Add discount to product detail pages

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -300,5 +300,16 @@ footer {
   border-top: 1px solid var(--accent1);
   margin-top: 1rem;
 }
+/* AD-Clase para aplicar el descuento */
+.discount-badge {
+  background-color: var(--tertiary-color);
+  color: white;
+  padding: 4px 8px;
+  font-size: var(--small-font);
+  font-weight: bold;
+  border-radius: 5px;
+  display: inline-block;
+  margin-left: 10px;
+}
 
 

--- a/src/js/ProductList.mjs
+++ b/src/js/ProductList.mjs
@@ -1,18 +1,34 @@
 import { renderListWithTemplate } from "./utils.mjs";
 
 function productCardTemplate(product) {
+  // AD- Extract product details for cleaner code
+  const { Id, Image, Name, Brand, FinalPrice, SuggestedRetailPrice } = product;
+  
+  // AD- Initialize discountTag to avoid reference errors
+  let discountTag = "";
+  
+  // AD- Check if the product is discounted
+  if (FinalPrice < SuggestedRetailPrice) {
+    // AD- Calculate the discount percentage dynamically
+    const discountPercentage = ((SuggestedRetailPrice - FinalPrice) / SuggestedRetailPrice) * 100;
+    // AD- Create an HTML tag displaying the discount percentage
+    discountTag = `<span class="discount-badge">-${Math.round(discountPercentage)}% OFF</span>`;
+  }
+  // AD- Return the product card structure with the discount indicator if applicable
   return `
     <li class="product-card">
-      <a href="product_pages/?product=${product.Id}">
-      <img src="${product.Image}" alt="${product.Name}">
-      <h2>${product.Brand.Name}</h2>
-      <h3>${product.Name}</h3>
-      <p class="product-card__price">$${product.FinalPrice}</p>
+      <a href="product_pages/?product=${Id}">
+      <img src="${Image}" alt="${Name}">
+      <h2>${Brand.Name}</h2>
+      <h3>${Name}</h3>
+      <p class="product-card__price">$${FinalPrice.toFixed(2)}</p>
+      ${discountTag} <!-- Agregamos el indicador de descuento -->
       </a>
     </li>
-    `;
+  `;
 }
 
+// AD- Class responsible for managing the product list on the page
 export default class ProducList {
   constructor(category, datasSource, listElement) {
     this.category = category;
@@ -20,16 +36,14 @@ export default class ProducList {
     this.listElement = listElement;
   }
 
+  // AD- Method to initialize product loading
   async init() {
     const list = await this.datasSource.getData();
     this.renderList(list);
   }
 
+  // AD- Method that renders the product list on the page
   renderList(list) {
-    // const htmlStrings = list.map(productCardTemplate);
-    // this.listElement.insertAdjacentHTML("afterbegin", htmlStrings.join(""));
-
-    // apply use new utility function instead of the commented code above
     renderListWithTemplate(productCardTemplate, this.listElement, list);
   }
 }


### PR DESCRIPTION
Hi Ricardo and Team,

This pull request introduces a visual discount indicator for products displayed on the listing page. If a product’s FinalPrice is lower than its SuggestedRetailPrice, a badge showing the percentage discount is added.

I verified its functionality in the browser and confirmed that the styles remain consistent with the existing design 😉

Modified Files:
src/js/ProductList.mjs: Added logic to calculate and display the discount percentage.

src/css/style.css: Styled the discount badge for better visibility.

Let me know if you’d like any adjustments before merge.

